### PR TITLE
(WIP) fix logging under /tmp

### DIFF
--- a/jubatusonyarn/build.sbt
+++ b/jubatusonyarn/build.sbt
@@ -10,7 +10,7 @@ val SCALA_VERSION = "2.10.4"
 val VERSION = "1.1"
 
 val JUBATUS_DEPENDENCIES = Seq(
-  ("us.jubat" % "jubatus" % "0.7.1").exclude("org.jboss.netty", "netty"),
+  ("us.jubat" % "jubatus" % "0.8.0").exclude("org.jboss.netty", "netty"),
   "org.apache.hadoop" % "hadoop-common" % "2.3.0-cdh5.1.3" % "provided",
   "org.apache.hadoop" % "hadoop-hdfs" % "2.3.0-cdh5.1.3" % "provided",
   "org.apache.hadoop" % "hadoop-yarn-client" % "2.3.0-cdh5.1.3" % "provided"

--- a/jubatusonyarn/jubatus-on-yarn-application-master/src/main/scala/us/jubat/yarn/applicationmaster/ApplicationMasterApp.scala
+++ b/jubatusonyarn/jubatus-on-yarn-application-master/src/main/scala/us/jubat/yarn/applicationmaster/ApplicationMasterApp.scala
@@ -118,6 +118,15 @@ class ApplicationMasterParams {
   @org.kohsuke.args4j.Option(name = "--virtual-cores")
   var virtualCores: Int = 1
 
+  @org.kohsuke.args4j.Option(name = "--container-memory")
+  var containerMemory: Int = 128
+
+  @org.kohsuke.args4j.Option(name = "--container-nodes")
+  var containerNodes: String = ""
+
+  @org.kohsuke.args4j.Option(name = "--container-racks")
+  var containerRacks: String = ""
+
 
   @org.kohsuke.args4j.Option(name = "--learning-machine-name")
   var learningMachineName: String = ""
@@ -148,4 +157,15 @@ class ApplicationMasterParams {
 
   @org.kohsuke.args4j.Option(name = "--base-path")
   var basePath: String = ""
+
+  override def toString(): String = {
+    val text = s"""applicationName: $applicationName, nodes: $nodes, priority: $priority,
+      memory: $memory, virtualCores: $virtualCores, containerMemory: $containerMemory,
+      containerNodes: $containerNodes, containerRacks: $containerRacks, learningMachineName: $learningMachineName,
+      learningMachineType: $learningMachineType, zooKeepers: $zooKeepers, managementAddress: $managementAddress,
+      managementPort: $managementPort, applicationMasterNodeAddress: $applicationMasterNodeAddress,
+      jubatusProxyPort: $jubatusProxyPort, jubatusProxyProcessId: $jubatusProxyProcessId
+      """.stripMargin.trim
+    text
+  }
 }

--- a/jubatusonyarn/jubatus-on-yarn-application-master/src/test/resources/entrypoint.sh
+++ b/jubatusonyarn/jubatus-on-yarn-application-master/src/test/resources/entrypoint.sh
@@ -27,7 +27,7 @@ for i in `seq 10`; do
     fi
   done
 
-  echo juba${LEARNING_MACHINE_TYPE} --zookeeper=${ZOOKEEPER} --interval_sec=10 --interval_count=0 --rpc-port=${JUBATUS_SERVER_PORT} --name=${LEARNING_MACHINE_NAME} --listen_if ${LISTEN_IF} >> /tmp/Container 2>&1
+  echo juba${LEARNING_MACHINE_TYPE} --zookeeper=${ZOOKEEPER} --interval_sec=10 --interval_count=0 --rpc-port=${JUBATUS_SERVER_PORT} --name=${LEARNING_MACHINE_NAME} --listen_if ${LISTEN_IF}
   juba${LEARNING_MACHINE_TYPE} --zookeeper=${ZOOKEEPER} --interval_sec=10 --interval_count=0 --rpc-port=${JUBATUS_SERVER_PORT} --name=${LEARNING_MACHINE_NAME} --listen_if ${LISTEN_IF} &
   JUBATUS_SERVER_PROCESS_ID=$!
 
@@ -37,7 +37,7 @@ for i in `seq 10`; do
       continue 2
     fi
 
-    echo jubactl --zookeeper=${ZOOKEEPER} --server=juba${LEARNING_MACHINE_TYPE} --type=${LEARNING_MACHINE_TYPE} --name=${LEARNING_MACHINE_NAME} --cmd status >> /tmp/Container 2>&1
+    echo jubactl --zookeeper=${ZOOKEEPER} --server=juba${LEARNING_MACHINE_TYPE} --type=${LEARNING_MACHINE_TYPE} --name=${LEARNING_MACHINE_NAME} --cmd status
     if (jubactl --zookeeper=${ZOOKEEPER} --server=juba${LEARNING_MACHINE_TYPE} --type=${LEARNING_MACHINE_TYPE} --name=${LEARNING_MACHINE_NAME} --cmd status \
         | awk '/active '${LEARNING_MACHINE_NAME}' members:/ {flag=1; next} /active/ {flag=0} flag==1 {print}' \
         | grep "^${IP_ADDRESS}_${JUBATUS_SERVER_PORT}$"); then
@@ -57,11 +57,11 @@ fi
 echo $JAVA_HOME/bin/java -Xmx${CONTAINER_MEMORY_SIZE}M ${CONTAINER_JRA_MAIN_CLASS} --seq ${SEQ} \
     --application-name ${APPLICATION_NAME} --application-master-address ${APPLICATION_MASTER_ADDRESS} --application-master-port ${APPLICATION_MASTER_PORT} \
     --container-node-address ${IP_ADDRESS} --jubatus-server-port ${JUBATUS_SERVER_PORT} --jubatus-server-process-id ${JUBATUS_SERVER_PROCESS_ID} \
-    --learning-machine-name ${LEARNING_MACHINE_NAME} --learning-machine-type ${LEARNING_MACHINE_TYPE} >> /tmp/Container 2>&1
+    --learning-machine-name ${LEARNING_MACHINE_NAME} --learning-machine-type ${LEARNING_MACHINE_TYPE}
 $JAVA_HOME/bin/java -Xmx${CONTAINER_MEMORY_SIZE}M ${CONTAINER_JRA_MAIN_CLASS} --seq ${SEQ} \
     --application-name ${APPLICATION_NAME} --application-master-address ${APPLICATION_MASTER_ADDRESS} --application-master-port ${APPLICATION_MASTER_PORT} \
     --container-node-address ${IP_ADDRESS} --jubatus-server-port ${JUBATUS_SERVER_PORT} --jubatus-server-process-id ${JUBATUS_SERVER_PROCESS_ID} \
-    --learning-machine-name ${LEARNING_MACHINE_NAME} --learning-machine-type ${LEARNING_MACHINE_TYPE} >> /tmp/Container 2>&1
+    --learning-machine-name ${LEARNING_MACHINE_NAME} --learning-machine-type ${LEARNING_MACHINE_TYPE}
 EXIT_CODE=$?
 ps ${JUBATUS_SERVER_PROCESS_ID} && kill ${JUBATUS_SERVER_PROCESS_ID}
 exit $EXIT_CODE

--- a/jubatusonyarn/jubatus-on-yarn-client/src/main/scala/us/jubat/yarn/client/JubatusYarnApplication.scala
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/main/scala/us/jubat/yarn/client/JubatusYarnApplication.scala
@@ -15,7 +15,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 package us.jubat.yarn.client
 
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{Path, FileSystem}
 import scala.concurrent.Future
 import scala.util.{Success, Failure, Try}
 import java.net.InetAddress
@@ -23,15 +23,27 @@ import us.jubat.yarn.common._
 import scala.Some
 import us.jubat.yarn.client.JubatusYarnApplication.ApplicationContext
 import org.apache.hadoop.yarn.api.records.{FinalApplicationStatus, ApplicationReport}
+import org.apache.hadoop.yarn.conf.YarnConfiguration
 
 // TODO ExecutionContextをとりあえず追加。これで問題ないかあとで確認。
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+object Resource {
+  val defaultMasterMemory: Int = 128
+  val defaultJubatusProxyMemory: Int = 32
+  val defaultMasterCores: Int = 1
+  val defaultPriority: Int = 0
+  val defaultContainerMemory: Int = 128
+  val defaultJubatusServerMemory: Int = 256
+  val defaultContainerCores: Int = 1
+}
+case class Resource(priority: Int = Resource.defaultPriority, memory: Int = Resource.defaultJubatusServerMemory,
+    virtualCores: Int = Resource.defaultContainerCores, masterMemory: Int = Resource.defaultMasterMemory,
+    proxyMemory: Int = Resource.defaultJubatusProxyMemory, masterCores: Int = Resource.defaultMasterCores,
+    containerMemory: Int = Resource.defaultContainerMemory, containerNodes: List[String] = null, containerRacks: List[String] = null)
 
-case class Resource(priority: Int, memory: Int, virtualCores: Int)
-
-case class JubatusYarnApplicationStatus(jubatusProxy: java.util.Map[String, java.util.Map[String, String]], jubatusServers: java.util.Map[String, java.util.Map[String, String]], yarnApplication: ApplicationReport)
+case class JubatusYarnApplicationStatus(jubatusProxy: java.util.Map[String, java.util.Map[String, String]], jubatusServers: java.util.Map[String, java.util.Map[String, String]], yarnApplication: java.util.Map[String, Any])
 
 object JubatusYarnApplication extends HasLogger {
 
@@ -85,7 +97,26 @@ object JubatusYarnApplication extends HasLogger {
    * @return  [[JubatusYarnApplication]]
    */
   def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigString: String, aResource: Resource, aNodeCount: Int): Future[JubatusYarnApplication] = {
-    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigString, aResource, aNodeCount, new Path("hdfs:///jubatus-on-yarn"))
+    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigString, aResource, aNodeCount, new Path("hdfs:///jubatus-on-yarn"), null)
+  }
+
+  /**
+   * JubatusYarnApplication を起動します。
+   *
+   * juba${aLearningMachineType_proxy} がひとつ, juba${aLearningMachineType} が ${aNodeCount} だけ起動します。
+   * 各 juba${aLearningMachineType} の使用するリソースを ${aResource} に指定してください。
+   *
+   * @param aLearningMachineName  learning machine name
+   * @param aLearningMachineType  learning machine type
+   * @param aZookeepers ZooKeeper locations
+   * @param aConfigString config json string
+   * @param aResource  computer resources in the cluster
+   * @param aNodeCount  number of cluster
+   * @param aApplicationName yarn-application name
+   * @return  [[JubatusYarnApplication]]
+   */
+  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigString: String, aResource: Resource, aNodeCount: Int, aApplicationName: String): Future[JubatusYarnApplication] = {
+    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigString, aResource, aNodeCount, new Path("hdfs:///jubatus-on-yarn"), aApplicationName)
   }
 
   /**
@@ -103,7 +134,27 @@ object JubatusYarnApplication extends HasLogger {
    * @param aBasePath base path of jar and sh files
    * @return  [[JubatusYarnApplication]]
    */
-  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigString: String, aResource: Resource, aNodeCount: Int, aBasePath: Path): Future[JubatusYarnApplication] = Future {
+  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigString: String, aResource: Resource, aNodeCount: Int, aBasePath: Path): Future[JubatusYarnApplication] = {
+    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigString, aResource, aNodeCount, aBasePath, null)
+  }
+
+  /**
+   * JubatusYarnApplication を起動します。
+   *
+   * juba${aLearningMachineType_proxy} がひとつ, juba${aLearningMachineType} が ${aNodeCount} だけ起動します。
+   * 各 juba${aLearningMachineType} の使用するリソースを ${aResource} に指定してください。
+   *
+   * @param aLearningMachineName  learning machine name
+   * @param aLearningMachineType  learning machine type
+   * @param aZookeepers ZooKeeper locations
+   * @param aConfigString config json string
+   * @param aResource  computer resources in the cluster
+   * @param aNodeCount  number of cluster
+   * @param aBasePath base path of jar and sh files
+   * @param aApplicationName yarn-application name
+   * @return  [[JubatusYarnApplication]]
+   */
+  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigString: String, aResource: Resource, aNodeCount: Int, aBasePath: Path, aApplicationName: String): Future[JubatusYarnApplication] = Future {
     require(aResource.memory > 0, "specify memory than 1MB.")
     require(aNodeCount > 0, "specify node count than 1")
 
@@ -114,8 +165,8 @@ object JubatusYarnApplication extends HasLogger {
       case None => throw new IllegalStateException("Service not running.")
       case Some(tYarnClientController) =>
         // ApplicationMaster 起動
-        logger.info(s"startJubatusApplication $aLearningMachineName, $aLearningMachineType, $aZookeepers, $aConfigString, $aResource, $aNodeCount")
-        val tApplicationMasterProxy = tYarnClientController.startJubatusApplication(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigString, aResource, aNodeCount, aBasePath)
+        logger.info(s"startJubatusApplication $aLearningMachineName, $aLearningMachineType, $aZookeepers, $aConfigString, $aResource, $aNodeCount, $aApplicationName")
+        val tApplicationMasterProxy = tYarnClientController.startJubatusApplication(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigString, aResource, aNodeCount, aBasePath, aApplicationName)
         waitForStarted(ApplicationContext(tYarnClientController, tApplicationMasterProxy, tService))
     }
   }
@@ -135,7 +186,26 @@ object JubatusYarnApplication extends HasLogger {
    * @return  [[JubatusYarnApplication]]
    */
   def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigFile: Path, aResource: Resource, aNodeCount: Int): Future[JubatusYarnApplication] = {
-    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigFile, aResource, aNodeCount, new Path("hdfs:///jubatus-on-yarn"))
+    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigFile, aResource, aNodeCount, new Path("hdfs:///jubatus-on-yarn"), null)
+  }
+
+  /**
+   * JubatusYarnApplication を起動します。
+   *
+   * juba${aLearningMachineType_proxy} がひとつ, juba${aLearningMachineType} が ${aNodeCount} だけ起動します。
+   * 各 juba${aLearningMachineType} の使用するリソースを ${aResource} に指定してください。
+   *
+   * @param aLearningMachineName  learning machine name
+   * @param aLearningMachineType  learning machine type
+   * @param aZookeepers ZooKeeper locations
+   * @param aConfigFile config file
+   * @param aResource  computer resources in the cluster
+   * @param aNodeCount  number of cluster
+   * @param aApplicationName yarn-application name
+   * @return  [[JubatusYarnApplication]]
+   */
+  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigFile: Path, aResource: Resource, aNodeCount: Int, aApplicationName: String): Future[JubatusYarnApplication] = {
+    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigFile, aResource, aNodeCount, new Path("hdfs:///jubatus-on-yarn"), aApplicationName)
   }
 
   /**
@@ -152,7 +222,26 @@ object JubatusYarnApplication extends HasLogger {
    * @param aNodeCount  number of cluster
    * @return  [[JubatusYarnApplication]]
    */
-  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigFile: Path, aResource: Resource, aNodeCount: Int, aBasePath: Path): Future[JubatusYarnApplication] = Future {
+  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigFile: Path, aResource: Resource, aNodeCount: Int, aBasePath: Path): Future[JubatusYarnApplication] = {
+    start(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigFile, aResource, aNodeCount, aBasePath,  null)
+  }
+
+  /**
+   * JubatusYarnApplication を起動します。
+   *
+   * juba${aLearningMachineType_proxy} がひとつ, juba${aLearningMachineType} が ${aNodeCount} だけ起動します。
+   * 各 juba${aLearningMachineType} の使用するリソースを ${aResource} に指定してください。
+   *
+   * @param aLearningMachineName  learning machine name
+   * @param aLearningMachineType  learning machine type
+   * @param aZookeepers ZooKeeper locations
+   * @param aConfigFile config file
+   * @param aResource  computer resources in the cluster
+   * @param aNodeCount  number of cluster
+   * @param aApplicationName yarn-application name
+   * @return  [[JubatusYarnApplication]]
+   */
+  def start(aLearningMachineName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigFile: Path, aResource: Resource, aNodeCount: Int, aBasePath: Path, aApplicationName: String): Future[JubatusYarnApplication] = Future {
     require(aResource.memory > 0, "specify memory than 1MB.")
     require(aNodeCount > 0, "specify node count than 1")
 
@@ -163,8 +252,8 @@ object JubatusYarnApplication extends HasLogger {
       case None => throw new IllegalStateException("Service not running.")
       case Some(tYarnClientController) =>
         // ApplicationMaster 起動
-        logger.info(s"startJubatusApplication $aLearningMachineName, $aLearningMachineType, $aZookeepers, $aConfigFile, $aResource, $aNodeCount")
-        val tApplicationMasterProxy = tYarnClientController.startJubatusApplication(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigFile, aResource, aNodeCount, aBasePath)
+        logger.info(s"startJubatusApplication $aLearningMachineName, $aLearningMachineType, $aZookeepers, $aConfigFile, $aResource, $aNodeCount, $aApplicationName")
+        val tApplicationMasterProxy = tYarnClientController.startJubatusApplication(aLearningMachineName, aLearningMachineType, aZookeepers, aConfigFile, aResource, aNodeCount, aBasePath, aApplicationName)
         waitForStarted(ApplicationContext(tYarnClientController, tApplicationMasterProxy, tService))
     }
   }
@@ -222,6 +311,24 @@ class JubatusYarnApplication(val jubatusProxy: Location, val jubatusServers: Lis
    */
   def loadModel(aModelPathPrefix: Path, aModelId: String): Try[JubatusYarnApplication] = Try {
     logger.info(s"loadModel $aModelPathPrefix, $aModelId")
+
+    val tHdfs = FileSystem.get(new YarnConfiguration())
+    val srcPath = new Path(aModelPathPrefix, aModelId)
+    if (!tHdfs.exists(srcPath)) {
+      val msg = s"model path does not exist ($srcPath)"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    }
+
+    for (i <- 0 to jubatusServers.size - 1) {
+      val srcFile = new Path(srcPath, s"$i.jubatus")
+      if (!tHdfs.exists(srcFile)) {
+        val msg = s"model file does not exist ($srcFile)"
+        logger.error(msg)
+        throw new RuntimeException(msg)
+      }
+    }
+
     aContext.controller.loadModel(aModelPathPrefix, aModelId)
     this
   }

--- a/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/.gitignore
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/.gitignore
@@ -1,0 +1,2 @@
+core-site.xml
+yarn-site.xml

--- a/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/core-site.xml.dist
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/core-site.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<!--
+  This file is a template file of core-site.xml.
+  A user should replace [value]s in this file to actual values and rename to core-site.xml.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://[host]:[port]</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.mapred.groups</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.mapred.hosts</name>
+    <value>*</value>
+  </property>
+</configuration>

--- a/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/jubatus_config.json
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/jubatus_config.json
@@ -1,0 +1,1 @@
+{"method":"AROW","parameter":{"regularization_weight":1.0},"converter":{"num_filter_types":{},"num_filter_rules":[],"string_filter_types":{},"string_filter_rules":[],"num_types":{},"num_rules":[{"key":"*","type":"num"}],"string_types":{"unigram":{"method":"ngram","char_num":"1"}},"string_rules":[{"key":"*","type":"unigram","sample_weight":"bin","global_weight":"bin"}]}}

--- a/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/yarn-site.xml.dist
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/test/resources/yarn-site.xml.dist
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+  This file is a template file of yarn-site.xml.
+  A user should replace path in this file to actual values and rename to yarn-site.xml.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
+    <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+  </property>
+
+  <property>
+    <name>yarn.log-aggregation-enable</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <description>List of directories to store localized files in.</description>
+    <name>yarn.nodemanager.local-dirs</name>
+    <value>file:///var/lib/hadoop-yarn/cache/${user.name}/nm-local-dir</value>
+  </property>
+
+  <property>
+    <description>Where to store container logs.</description>
+    <name>yarn.nodemanager.log-dirs</name>
+    <value>file:///var/log/hadoop-yarn/containers</value>
+  </property>
+<!--
+  <property>
+    <description>Where to aggregate logs to.</description>
+    <name>yarn.nodemanager.remote-app-log-dir</name>
+    <value>hdfs://var/log/hadoop-yarn/apps</value>
+  </property>
+-->
+  <property>
+    <description>Classpath for typical applications.</description>
+     <name>yarn.application.classpath</name>
+     <value>
+        $HADOOP_CONF_DIR,
+        $HADOOP_COMMON_HOME/*,$HADOOP_COMMON_HOME/lib/*,
+        $HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,
+        $HADOOP_MAPRED_HOME/*,$HADOOP_MAPRED_HOME/lib/*,
+        $HADOOP_YARN_HOME/*,$HADOOP_YARN_HOME/lib/*
+     </value>
+  </property>
+</configuration>

--- a/jubatusonyarn/jubatus-on-yarn-client/src/test/scala/us/jubat/yarn/client/JubatusYarnApplicationSpec.scala
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/test/scala/us/jubat/yarn/client/JubatusYarnApplicationSpec.scala
@@ -1,0 +1,169 @@
+package us.jubat.yarn.client
+
+import org.scalatest._
+import us.jubat.yarn.common.Location
+import us.jubat.yarn.common.LearningMachineType
+import org.apache.hadoop.fs.{Path, FileSystem}
+import org.apache.hadoop.fs.permission.FsPermission
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+import scala.util._
+import scala.concurrent.duration.Duration
+import scala.sys.process.{Process, ProcessBuilder}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.hadoop.yarn.api.records.ApplicationReport
+
+class JubatusYarnApplicationSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  val machineType = LearningMachineType.Classifier
+  val zookeeper = new Location("localhost", 2181)
+  val configString = """{"method":"AROW","parameter":{"regularization_weight":1.0},"converter":{"num_filter_types":{},"num_filter_rules":[],"string_filter_types":{},"string_filter_rules":[],"num_types":{},"num_rules":[{"key":"*","type":"num"}],"string_types":{"unigram":{"method":"ngram","char_num":"1"}},"string_rules":[{"key":"*","type":"unigram","sample_weight":"bin","global_weight":"bin"}]}}"""
+  val basePath = new Path("hdfs:///jubatus-on-yarn/")
+  val configPath = new Path("hdfs:///jubatus-on-yarn/test/jubatus_config.json")
+
+  override def beforeAll(): Unit = {
+    //テストデータの配置
+    val conf = new Configuration()
+    val fs = configPath.getFileSystem(conf)
+    if (!fs.exists(configPath)) {
+      val localPath = new Path("jubatus-on-yarn-client/src/test/resources/jubatus_config.json")
+      fs.copyFromLocalFile(localPath, configPath)
+    }
+  }
+
+  // start()結果からアプリケーション名を取得する
+  private def getAppicationName(future: Future[JubatusYarnApplication]): String = {
+    var applicationName = ""
+    val result = future.andThen {
+      case Success(j) =>
+        val appReport: ApplicationReport = j.status.yarnApplication.get("applicationReport").asInstanceOf[ApplicationReport]
+        applicationName = appReport.getName
+        j.kill()
+      case Failure(t) =>
+        print("CREATE MODEL failed: " + t.getMessage)
+        t.printStackTrace()
+    }
+    Await.result(result, Duration.Inf)
+    return applicationName
+  }
+
+  "start ()" should "check ApplicationName" in {
+    //config parameter is String
+    //specific paramter: No Path and No ApplicationName
+    var future = JubatusYarnApplication.start("model1", machineType, List(zookeeper), configString, Resource(1, 1, 1), 3)
+    var resultName = getAppicationName(future)
+    resultName shouldBe "model1:" + machineType.name + ":" + zookeeper.hostAddress + ":" + zookeeper.port
+
+    //specific paramter: Path and No ApplicationName
+    future = JubatusYarnApplication.start("model2", machineType, List(zookeeper), configString, Resource(1, 1, 1), 3, basePath)
+    resultName = getAppicationName(future)
+    resultName shouldBe "model2:" + machineType.name + ":" + zookeeper.hostAddress + ":" + zookeeper.port
+
+    //specific paramter: No Path and ApplicationName
+    future = JubatusYarnApplication.start("model3", machineType, List(zookeeper), configString, Resource(1, 1, 1), 3, "dummyApplicationName3")
+    resultName = getAppicationName(future)
+    resultName shouldBe "dummyApplicationName3"
+
+    //specific paramter: Path and ApplicationName
+    future = JubatusYarnApplication.start("model4", machineType, List(zookeeper), configString, Resource(1, 1, 1), 3, basePath, "dummyApplicationName4")
+    resultName = getAppicationName(future)
+    resultName shouldBe "dummyApplicationName4"
+
+    //config parameter is Path
+    //specific paramter: No Path and No ApplicationName
+    future = JubatusYarnApplication.start("model5", machineType, List(zookeeper), configPath, Resource(1, 1, 1), 3)
+    resultName = getAppicationName(future)
+    resultName shouldBe "model5:" + machineType.name + ":" + zookeeper.hostAddress + ":" + zookeeper.port
+
+    //specific paramter: Path and No ApplicationName
+    future = JubatusYarnApplication.start("model6", machineType, List(zookeeper), configPath, Resource(1, 1, 1), 3, basePath)
+    resultName = getAppicationName(future)
+    resultName shouldBe "model6:" + machineType.name + ":" + zookeeper.hostAddress + ":" + zookeeper.port
+
+    //specific paramter: No Path and ApplicationName
+    future = JubatusYarnApplication.start("model7", machineType, List(zookeeper), configPath, Resource(1, 1, 1), 3, "dummyApplicationName7")
+    resultName = getAppicationName(future)
+    resultName shouldBe "dummyApplicationName7"
+
+    //specific paramter: Path and ApplicationName
+    future = JubatusYarnApplication.start("model8", machineType, List(zookeeper), configPath, Resource(1, 1, 1), 3, basePath, "dummyApplicationName8")
+    resultName = getAppicationName(future)
+    resultName shouldBe "dummyApplicationName8"
+  }
+
+  "loadModel()" should "loadModel for classifier" in {
+    var future = JubatusYarnApplication.start("test", machineType, List(zookeeper), configString, Resource(1, 1, 1), 1)
+    Await.ready(future, Duration.Inf)
+    val result = future.value.get
+    result match {
+      case Success(juba) =>
+        val tHdfs = FileSystem.get(new YarnConfiguration())
+        val srcFile = new Path("hdfs:///data/models/t1/test001/0.jubatus")
+        if (!tHdfs.exists(srcFile)) {
+          juba.saveModel(new Path("hdfs:///data/models/t1"), "test001")
+        }
+        val result: Try[JubatusYarnApplication] = juba.loadModel(new Path("hdfs:///data/models/t1"), "test001")
+
+        result shouldBe a[Success[_]]
+
+        Await.ready(juba.stop(), Duration.Inf)
+
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+
+  it should "loadModel a directory doesn't exist for classifier" in {
+    var future = JubatusYarnApplication.start("test", machineType, List(zookeeper), configString, Resource(1, 1, 1), 1)
+    Await.ready(future, Duration.Inf)
+    val result = future.value.get
+    result match {
+      case Success(juba) =>
+        val tHdfs = FileSystem.get(new YarnConfiguration())
+        val srcPath = new Path("hdfs:///data/models/t1/test001")
+        if (tHdfs.exists(srcPath)) {
+          tHdfs.delete(srcPath, true)
+        }
+        val result: Try[JubatusYarnApplication] = juba.loadModel(new Path("hdfs:///data/models/t1"), "test001")
+
+        result shouldBe a[Failure[_]]
+
+        Await.ready(juba.stop(), Duration.Inf)
+
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+
+  it should "loadModel a file doesn't exist for classifier" in {
+    var future = JubatusYarnApplication.start("test", machineType, List(zookeeper), configString, Resource(1, 1, 1), 1)
+    Await.ready(future, Duration.Inf)
+    val result = future.value.get
+    result match {
+      case Success(juba) =>
+        val tHdfs = FileSystem.get(new YarnConfiguration())
+        val srcFile = new Path("hdfs:///data/models/t1/test001/0.jubatus")
+        if (tHdfs.exists(srcFile)) {
+          tHdfs.delete(srcFile, false)
+        }
+        val srcPath = new Path("hdfs:///data/models/t1/test001")
+        if (!tHdfs.exists(srcPath)) {
+          tHdfs.mkdirs(srcPath)
+        }
+
+        val result: Try[JubatusYarnApplication] = juba.loadModel(new Path("hdfs:///data/models/t1"), "test001")
+
+        result shouldBe a[Failure[_]]
+
+        Await.ready(juba.stop(), Duration.Inf)
+        tHdfs.delete(srcPath, true)
+
+      case Failure(t) =>
+        t.printStackTrace()
+        fail()
+    }
+  }
+}

--- a/jubatusonyarn/jubatus-on-yarn-client/src/test/scala/us/jubat/yarn/client/YarnClientControllerSpec.scala
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/test/scala/us/jubat/yarn/client/YarnClientControllerSpec.scala
@@ -16,15 +16,16 @@
 package us.jubat.yarn.client
 
 import java.net.InetAddress
-
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.yarn.api.records.{FinalApplicationStatus, ApplicationReport, ApplicationId}
+import org.apache.hadoop.yarn.api.records.{FinalApplicationStatus, ApplicationReport, ApplicationId, YarnApplicationState}
 import org.scalatest._
 import us.jubat.yarn.common.{LearningMachineType, Location}
+import us.jubat.common.ClientBase
 
-class YarnClientControllerSpec extends FlatSpec with Matchers {
+class YarnClientControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   class DummyYarnClient extends YarnClient {
+
     override def submitApplicationMaster(aApplicationName: String, aLearningMachineInstanceName: String, aLearningMachineType: LearningMachineType, aZookeepers: List[Location], aConfigString: String, aResource: Resource, aNodes: Int, aManagementLocation: Location, aBasePath: Path): ApplicationId = {
       ApplicationId.newInstance(0, 0)
     }
@@ -33,14 +34,80 @@ class YarnClientControllerSpec extends FlatSpec with Matchers {
       ApplicationId.newInstance(0, 0)
     }
 
-    override def getStatus(aApplicationId: ApplicationId): ApplicationReport = ???
+    override def getStatus(aApplicationId: ApplicationId): ApplicationReport = {
+      val appId: ApplicationId = ApplicationId.newInstance(System.currentTimeMillis(), 1111)
+      ApplicationReport.newInstance(appId, null, "dummyUser", "dummyQueue", "dummyName",
+          "dummyHost", 0, null, YarnApplicationState.RUNNING, "", "url", System.currentTimeMillis(), 0,
+          FinalApplicationStatus.UNDEFINED, null, "origTrackingUrl", 0, "Classifier", null)
+    }
 
     override def kill(aApplicationId: ApplicationId): Unit = ???
 
     override def getFinalStatus(aApplicationId: ApplicationId): FinalApplicationStatus = ???
   }
 
-  def createController() = new YarnClientController(Location(InetAddress.getLocalHost, 0), new DummyYarnClient)
+  class DummyClient(host: String, port: Int, name: String) extends ClientBase(host, port, name, 10) {
+    override def getStatus(): java.util.Map[String, java.util.Map[String, String]] = {
+      val statusMap: java.util.Map[String, java.util.Map[String, String]] = new java.util.HashMap()
+      val subStatus: java.util.Map[String, String] = new java.util.HashMap()
+      subStatus.put("type", "classifier")
+      subStatus.put("VERSION", "0.8.1")
+      subStatus.put("PROGNAME", "jubaclassifier")
+      statusMap.put("server1", subStatus)
+      statusMap.put("server2", subStatus)
+      statusMap
+    }
+
+    override def getProxyStatus(): java.util.Map[String, java.util.Map[String, String]] = {
+      val statusMap: java.util.Map[String, java.util.Map[String, String]] = new java.util.HashMap()
+      val subStatus: java.util.Map[String, String] = new java.util.HashMap()
+      subStatus.put("user", "user")
+      subStatus.put("VERSION", "0.8.1")
+      subStatus.put("PROGNAME", "jubaclassifier_proxy")
+      statusMap.put("proxy1", subStatus)
+      statusMap
+    }
+  }
+
+  def createController() = new YarnClientController(Location(InetAddress.getLocalHost, 0), new DummyYarnClient())
+
+  "startJubatusApplication ()" should "check applicationName" in {
+
+    val machineType = LearningMachineType.Classifier
+    val zookeeper1 = new Location("localhost",2188)
+    val zookeeper2 = new Location("127.0.0.2",2189)
+
+    val tController = createController()
+
+    var result = tController.startJubatusApplication("model1", machineType, List(zookeeper1,zookeeper2), "configString", Resource(0, 0, 0), 3, null)
+    result.name shouldBe "model1:" + machineType.name + ":" + zookeeper1.hostAddress + ":" + zookeeper1.port + "," + zookeeper2.hostAddress + ":" + zookeeper2.port
+
+    result = tController.startJubatusApplication("model2", machineType, List(zookeeper1,zookeeper2), "configString", Resource(0, 0, 0), 3, null, "dummyApplicationName2")
+    result.name shouldBe "dummyApplicationName2"
+
+    result = tController.startJubatusApplication("model3", machineType, List(zookeeper1,zookeeper2), new Path("/tmp/dummyFile"), Resource(0, 0, 0), 3, null)
+    result.name shouldBe "model3:" + machineType.name + ":" + zookeeper1.hostAddress + ":" + zookeeper1.port + "," + zookeeper2.hostAddress + ":" + zookeeper2.port
+
+    result = tController.startJubatusApplication("model4", machineType, List(zookeeper1,zookeeper2), new Path("/tmp/dummyFile"), Resource(0, 0, 0), 3, null, "dummyApplicationName4")
+    result.name shouldBe "dummyApplicationName4"
+  }
+
+  "status()" should "success getStatus" in {
+
+    val machineType = LearningMachineType.Classifier
+    val zookeeper1 = new Location("localhost", 2188)
+    val tController = createController()
+    var result = tController.startJubatusApplication("model1", machineType, List(zookeeper1), "configString", Resource(0, 0, 0), 3, null)
+    tController.mClient = Some(new DummyClient("localhost", 9999, "name"))
+
+    val yarnAppStatus = tController.status
+    yarnAppStatus.jubatusProxy.size() shouldBe 1
+    yarnAppStatus.jubatusServers.size() shouldBe 2
+    yarnAppStatus.yarnApplication.size() shouldBe 3
+    yarnAppStatus.yarnApplication.get("applicationReport") should not be None
+    yarnAppStatus.yarnApplication.get("currentTime") should not be None
+    yarnAppStatus.yarnApplication.get("oparatingTime") should not be None
+  }
 
 //  "start one" should "not throw exception" in {
 //    val tController = createController()

--- a/jubatusonyarn/jubatus-on-yarn-client/src/test/scala/us/jubat/yarn/client/YarnClientSpec.scala
+++ b/jubatusonyarn/jubatus-on-yarn-client/src/test/scala/us/jubat/yarn/client/YarnClientSpec.scala
@@ -1,0 +1,57 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2014-2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.yarn.client
+
+import org.scalatest._
+import us.jubat.yarn.common.{Location, LearningMachineType}
+import org.apache.hadoop.fs.Path
+
+class YarnClientSpec extends FlatSpec with Matchers {
+  val zookeeper = new Location("localhost", 2181)
+  val configString = """{"method":"AROW","parameter":{"regularization_weight":1.0}}"""
+  val manageLocation = new Location("localhost", 9300)
+  val basePath = new Path("hdfs:///jubatus-on-yarn")
+
+  "submitApplicationMaster ()" should "success recource config" in {
+
+    val yarnClient = new DefaultYarnClient()
+
+    try {
+      // デフォルト
+      var resource = Resource()
+      yarnClient.submitApplicationMaster("TestApp1", "model1", LearningMachineType.Classifier, List(zookeeper),
+          configString, resource, 3, manageLocation, basePath)
+
+      // ログ(submit ApplicationMaster)を目視確認
+      // command: bash [entrypoint] [jar] [class] 128 [ap] [host] [port] [nodes] 0 256 1 128 \"\" \"\" [model] [type] [zookeeper] [config] [basepath] [stdout] [stderr]
+      // memory: 32+128 = 160
+      // virtualCores: 1
+
+      resource = Resource(1, 512, 2, 256, 128, 3, 256, List("1"), List("1", "2"))
+      yarnClient.submitApplicationMaster("TestApp1", "model1", LearningMachineType.Classifier, List(zookeeper),
+          configString, resource, 3, manageLocation, basePath)
+
+      // ログ(submit ApplicationMaster)を目視確認
+      // command: bash [entrypoint] [jar] [class] 256 [ap] [host] [port] [nodes] 1 512 2 256 "1" "1,2" [model] [type] [zookeeper] [config] [basepath] [stdout] [stderr]
+      // memory: 128+256 = 384
+      // virtualCores: 3
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace()
+        fail()
+    }
+  }
+}

--- a/jubatusonyarn/jubatus-on-yarn-container/src/main/scala/us/jubat/yarn/container/ContainerController.scala
+++ b/jubatusonyarn/jubatus-on-yarn-container/src/main/scala/us/jubat/yarn/container/ContainerController.scala
@@ -100,21 +100,24 @@ class ContainerController(name: String, seq: Int, applicationMasterLocation: Loc
 
     val tLocalPathString = s"${tIpPort}_${tType}_$aId.jubatus"
 
-    // CRCファイルが存在する場合は削除する。
-    {
-      val tCRC = new File(tDir, s".$tLocalPathString.crc")
-      if(tCRC.exists()) tCRC.delete()
-    }
+    try {
+      // CRCファイルが存在する場合は削除する。
+      {
+        val tCRC = new File(tDir, s".$tLocalPathString.crc")
+        if(tCRC.exists()) tCRC.delete()
+      }
 
-    // ローカルファイルをコピー
-    {
-      val tHdfs = FileSystem.get(new YarnConfiguration())
-      val tFromLocal = new Path(tDir, tLocalPathString)
-      val tToHdfs = new Path(aPathPrefix, s"$aId/$seq.jubatus")
-      tHdfs.copyFromLocalFile(true, true, tFromLocal, tToHdfs)
+      // ローカルファイルをコピー
+      {
+        val tHdfs = FileSystem.get(new YarnConfiguration())
+        val tFromLocal = new Path(tDir, tLocalPathString)
+        val tToHdfs = new Path(aPathPrefix, s"$aId/$seq.jubatus")
+        tHdfs.copyFromLocalFile(true, true, tFromLocal, tToHdfs)
+      }
+    } finally {
+      mStatus = ControllerStatus.Wait
+      logger.debug(s"save: mStatus:$mStatus")
     }
-
-    mStatus = ControllerStatus.Wait
   }
 
   /**
@@ -127,9 +130,13 @@ class ContainerController(name: String, seq: Int, applicationMasterLocation: Loc
   def load(aPathPrefix: String, aId: String): Unit = {
     requireState(mStatus == ControllerStatus.Wait)
     mStatus = ControllerStatus.Loading
-    val (tIpPort, tDir, tType) = getJubatusConfig
-    FileSystem.get(new YarnConfiguration()).copyToLocalFile(false, new Path(aPathPrefix, s"$aId/$seq.jubatus"), new Path(tDir, s"${tIpPort}_${tType}_$aId.jubatus"))
-    mStatus = ControllerStatus.Wait
+    try {
+      val (tIpPort, tDir, tType) = getJubatusConfig
+      FileSystem.get(new YarnConfiguration()).copyToLocalFile(false, new Path(aPathPrefix, s"$aId/$seq.jubatus"), new Path(tDir, s"${tIpPort}_${tType}_$aId.jubatus"))
+    } finally {
+      mStatus = ControllerStatus.Wait
+      logger.debug(s"load: mStatus:$mStatus")
+    }
   }
 
   /**

--- a/jubatusonyarn/jubatus-on-yarn-container/src/test/resources/core-site.xml.dist
+++ b/jubatusonyarn/jubatus-on-yarn-container/src/test/resources/core-site.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<!--
+  This file is a template file of core-site.xml.
+  A user should replace [value]s in this file to actual values and rename to core-site.xml.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://[host]:[port]</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.mapred.groups</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.mapred.hosts</name>
+    <value>*</value>
+  </property>
+</configuration>

--- a/jubatusonyarn/jubatus-on-yarn-container/src/test/resources/yarn-site.xml.dist
+++ b/jubatusonyarn/jubatus-on-yarn-container/src/test/resources/yarn-site.xml.dist
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+  This file is a template file of yarn-site.xml.
+  A user should replace path in this file to actual values and rename to yarn-site.xml.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
+    <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+  </property>
+
+  <property>
+    <name>yarn.log-aggregation-enable</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <description>List of directories to store localized files in.</description>
+    <name>yarn.nodemanager.local-dirs</name>
+    <value>file:///var/lib/hadoop-yarn/cache/${user.name}/nm-local-dir</value>
+  </property>
+
+  <property>
+    <description>Where to store container logs.</description>
+    <name>yarn.nodemanager.log-dirs</name>
+    <value>file:///var/log/hadoop-yarn/containers</value>
+  </property>
+<!--
+  <property>
+    <description>Where to aggregate logs to.</description>
+    <name>yarn.nodemanager.remote-app-log-dir</name>
+    <value>hdfs://var/log/hadoop-yarn/apps</value>
+  </property>
+-->
+  <property>
+    <description>Classpath for typical applications.</description>
+     <name>yarn.application.classpath</name>
+     <value>
+        $HADOOP_CONF_DIR,
+        $HADOOP_COMMON_HOME/*,$HADOOP_COMMON_HOME/lib/*,
+        $HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,
+        $HADOOP_MAPRED_HOME/*,$HADOOP_MAPRED_HOME/lib/*,
+        $HADOOP_YARN_HOME/*,$HADOOP_YARN_HOME/lib/*
+     </value>
+  </property>
+</configuration>

--- a/jubatusonyarn/jubatus-on-yarn-container/src/test/scala/us/jubat/yarn/container/ContainerControllerSpec.scala
+++ b/jubatusonyarn/jubatus-on-yarn-container/src/test/scala/us/jubat/yarn/container/ContainerControllerSpec.scala
@@ -1,0 +1,199 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2014-2015 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+package us.jubat.yarn.container
+
+import org.scalatest._
+import java.net.{InetSocketAddress, InetAddress}
+import us.jubat.yarn.common._
+import org.apache.hadoop.fs.{Path, FileSystem}
+import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.eclipse.jetty.server.Server
+import scala.util.{Failure, Success, Try}
+
+class ContainerControllerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  private var Controller: ContainerController = null
+  private var tAmJettyServer: JettyServer = null
+  private var tCnJettyServer: JettyServer = null
+  private var dmyJubaServer: DummyJubatusServer = null
+
+  override def beforeAll(): Unit = {
+    dmyJubaServer = new DummyJubatusServer
+    dmyJubaServer.start(9300)
+
+    val dmyAmServlet = new DummyApplicationMasterServlet
+    tAmJettyServer = new JettyServer("/v1", dmyAmServlet)
+    tAmJettyServer.start()
+
+    val tDmyCnServlet = new ContainerServlet
+    tCnJettyServer = new JettyServer("/v1", tDmyCnServlet)
+    tCnJettyServer.start()
+
+    val amLocation = new Location(InetAddress.getLocalHost, tAmJettyServer.getPort)
+    val cnLocation = new Location(InetAddress.getLocalHost, tCnJettyServer.getPort)
+    val location = new Location(InetAddress.getLocalHost, 9300)
+    val tJubatusConfig = new JubatusConfig(LearningMachineType.Classifier, "test", location, 5, 999)
+    Controller = new ContainerController("test", 0, amLocation, cnLocation, tJubatusConfig)
+  }
+
+  override protected def afterAll(): Unit = {
+    dmyJubaServer.stop()
+    tAmJettyServer.stop()
+    tCnJettyServer.stop()
+  }
+
+  "save()" should "save success" in {
+    val sFile = new java.io.File("/tmp/192.168.122.231_9300_classifier_test001.jubatus")
+    if (!sFile.exists()) {
+      sFile.createNewFile()
+    }
+
+    val tHdfs = FileSystem.get(new YarnConfiguration())
+    val tToHdfs = new Path("hdfs:///data/models/t1/test001/0.jubatus")
+    if (tHdfs.exists(tToHdfs)) {
+      tHdfs.delete(tToHdfs, false)
+    }
+
+    try {
+      Controller.save("hdfs:///data/models/t1", "test001")
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace()
+        fail()
+    }
+
+    tHdfs.exists(tToHdfs) shouldBe true
+  }
+
+  it should "save error exception" in {
+    val sFile = new java.io.File("/tmp/192.168.122.231_9300_classifier_test001.jubatus")
+    if (sFile.exists()) {
+      sFile.delete()
+    }
+
+    val tHdfs = FileSystem.get(new YarnConfiguration())
+    val tToHdfs = new Path("hdfs:///data/models/t1/test001/0.jubatus")
+    if (tHdfs.exists(tToHdfs)) {
+      tHdfs.delete(tToHdfs, false)
+    }
+
+    try {
+      Controller.save("hdfs:///data/models/t1", "test001")
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace()
+    }
+
+    tHdfs.exists(tToHdfs) shouldBe false
+  }
+
+  "load()" should "load success" in {
+    val dstFile = new java.io.File("/tmp/192.168.122.231_9300_classifier_test001.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+
+    val tHdfs = FileSystem.get(new YarnConfiguration())
+    val srcPath = new Path("hdfs:///data/models/t1/test001")
+    if (!tHdfs.exists(srcPath)) {
+      tHdfs.mkdirs(srcPath)
+    }
+    val srcFile = new Path("hdfs:///data/models/t1/test001/0.jubatus")
+    if (!tHdfs.exists(srcFile)) {
+      tHdfs.create(srcFile)
+    }
+
+    try {
+      Controller.load("hdfs:///data/models/t1", "test001")
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace()
+        fail()
+    }
+
+    dstFile.exists() shouldBe true
+  }
+
+  it should "load error exception" in {
+    val dstFile = new java.io.File("/tmp/192.168.122.231_9300_classifier_test001.jubatus")
+    if (dstFile.exists()) {
+      dstFile.delete()
+    }
+
+    val tHdfs = FileSystem.get(new YarnConfiguration())
+    val srcFile = new Path("hdfs:///data/models/t1/test001/0.jubatus")
+    if (tHdfs.exists(srcFile)) {
+      tHdfs.delete(srcFile, false)
+    }
+
+    try {
+      Controller.load("hdfs:///data/models/t1", "test001")
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace()
+    }
+
+    dstFile.exists() shouldBe false
+  }
+}
+
+class DummyApplicationMasterServlet() extends RestServlet {
+
+  put("/:seq/status") {
+    logger.info(
+      s"""put("/:seq=${params("seq")}/status") is called.
+        |${request.body}
+      """.stripMargin)
+    "OK"
+  }
+
+  put("/:seq/location") {
+    logger.info(
+      s"""put("/:seq=${params("seq")}/location") is called.
+        |${request.body}
+      """.stripMargin)
+    "OK"
+  }
+}
+
+class DummyJubatusServer {
+  var server: org.msgpack.rpc.Server = null
+
+  class JubaServer {
+    def get_status(): java.util.Map[String, java.util.Map[String, String]] = {
+      var ret: java.util.Map[String, java.util.Map[String, String]] = new java.util.HashMap()
+      var ret2: java.util.Map[String, String] = new java.util.HashMap()
+      ret2.put("datadir", "file:///tmp")
+      ret2.put("type", "classifier")
+      ret.put("192.168.122.231_9300", ret2)
+      ret
+    }
+
+  }
+
+  def start(id: Int) {
+    server = new org.msgpack.rpc.Server()
+    server.serve(new JubaServer())
+    server.listen(new InetSocketAddress(id))
+    println("*** DummyJubatusServer start ***")
+  }
+
+  def stop() {
+    server.close()
+    println("*** DummyJubatusServer stop ***")
+  }
+}
+


### PR DESCRIPTION
Currently jubatus-on-yarn prints logs to `/tmp/Container` and `/tmp/ApplicationMaster`.  logs instead should be printed to stdout, which will be captured by YARN Node Manager.
